### PR TITLE
Template improvements

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -23,10 +23,8 @@ wireguard:
         #Address: fe80::1/64, 10.0.0.1/24
         ListenPort: 51820
 
-        # It is very important to quote off. Jinja expands off without quotes to
-        # False which will result in 'table' not being set in the config file,
-        # resulting in defaulting to auto.
-        Table: 'off'
+        # booleans are converted automatically
+        Table: off
       peers:
         - PublicKey: foobar
           # AllowedIPs must be a list of strings or a comma separated string

--- a/wireguard/files/wg.conf
+++ b/wireguard/files/wg.conf
@@ -4,6 +4,9 @@
 {{key}} = {{item}}
 		{%- endfor -%}
 	{%- else -%}
+  {%- if value is sameas false %}
+  {%- set value = 'off' %}
+  {%- endif %}
 {{key}} = {{value}}
 	{%- endif -%}
 {%- endmacro -%}

--- a/wireguard/files/wg.conf
+++ b/wireguard/files/wg.conf
@@ -10,6 +10,7 @@
 {{key}} = {{value}}
 	{%- endif -%}
 {%- endmacro -%}
+{{ pillar.get('managed_by_salt', '# Managed by Salt!') }}
 [Interface]
 {%- for key, value in interface | dictsort -%}
 {{ output(key, value) }}

--- a/wireguard/files/wg.conf
+++ b/wireguard/files/wg.conf
@@ -1,22 +1,23 @@
 {%- macro output(key, value) -%}
-	{%- if value is iterable and value is not string -%}
+	{%- if value is iterable and value is not string %}
 		{%- for item in value %}
 {{key}} = {{item}}
-		{%- endfor -%}
-	{%- else -%}
-  {%- if value is sameas false %}
-  {%- set value = 'off' %}
+		{%- endfor %}
+	{%- else %}
+  {%- if value is sameas false -%}
+  {%- set value = 'off' -%}
   {%- endif %}
 {{key}} = {{value}}
 	{%- endif -%}
 {%- endmacro -%}
 [Interface]
-{% for key, value in interface.items() -%}
+{%- for key, value in interface | dictsort -%}
 {{ output(key, value) }}
-{% endfor -%}
-{%- for peer in peers %}
-[Peer]
-{% for key, value in peer.items() -%}
-{{ output(key, value) }}
-{% endfor -%}
 {%- endfor -%}
+{%- for peer in peers %}
+
+[Peer]
+{%- for key, value in peer | dictsort -%}
+{{ output(key, value) }}
+{%- endfor -%}
+{%- endfor %}

--- a/wireguard/files/wg.conf
+++ b/wireguard/files/wg.conf
@@ -1,7 +1,5 @@
 {%- macro output(key, value) -%}
-	{%- if value is string -%}
-{{key}} = {{value}}
-	{%- elif value is iterable -%}
+	{%- if value is iterable and value is not string -%}
 		{%- for item in value %}
 {{key}} = {{item}}
 		{%- endfor -%}


### PR DESCRIPTION
Hi,

## Commits:

**Patch 1:**

[Simplify string conditional](https://github.com/bmwiedemann/wireguard-formula/commit/481056310e4833bc4af7747eb9b02f0157a3d2ce)

Avoid code duplication between "is string" and "else".

**Patch 2:**

[Convert falsy booleans to off](https://github.com/bmwiedemann/wireguard-formula/commit/5b3cfb17bf5628b013620bb588d7f914bdbf419b)

Keep proper booleans in the pillar datastructure, cast them
transparently in the template.
This only considers "off" as wg-quick(8) at the time of writing does
not have any configuration options taking "on".

**Patch 3:**

[Improve spacing and sort options](https://github.com/bmwiedemann/wireguard-formula/commit/708c466abe005506999687e9a8697e75c2eb6195)

For better readability:
  - consistently separate sections with empty lines but not
    individual options within the sections
  - sort options

**Patch 4:**

[Add file header](https://github.com/bmwiedemann/wireguard-formula/pull/1/commits/14e0ee0597daebab34d0ca3830b36566068a44e7)

This adds a comment to the configuration files, indicating to
the administrator that it is managed by Salt.
A custom "managed_by_salt" pillar option, as is common in our
infrastructures, can be used to set a custom header, for example
to link a specific Git repository.

## Example pillar:

```
wireguard:
  interfaces:
    wg0:
      config:
        Address:
         - fe80::1/64
         - 10.0.0.1/24
        ListenPort: 51820
        Table: off
        PrivateKey: foo
      peers:
        - PublicKey: bar
          AllowedIPs: 127.0.0.1/32
        - PublicKey: baz
          AllowedIPs: 127.0.0.1/32
          PresharedKey: boo
```

## Before:

```
localhost:/srv # more /etc/wireguard/wg0.conf
[Interface]

Address = fe80::1/64
Address = 10.0.0.1/24
ListenPort = 51820
Table = False
PrivateKey = foo

[Peer]
PublicKey = bar
AllowedIPs = 127.0.0.1/32

[Peer]
PublicKey = baz
AllowedIPs = 127.0.0.1/32
PresharedKey = boo
```

## After:

```
localhost:/srv # more /etc/wireguard/wg0.conf
# Managed by Salt!
[Interface]
Address = fe80::1/64
Address = 10.0.0.1/24
ListenPort = 51820
PrivateKey = foo
Table = off

[Peer]
AllowedIPs = 127.0.0.1/32
PublicKey = bar

[Peer]
AllowedIPs = 127.0.0.1/32
PresharedKey = boo
PublicKey = baz
```