### PR TITLE
Reload instead of restart

### DIFF
--- a/wireguard/init.sls
+++ b/wireguard/init.sls
@@ -38,6 +38,7 @@ restart wg-quick@{{interface_name}}:
   service.running:
     - name: wg-quick@{{interface_name}}
     - enable: True
+    - reload: True
     - watch:
       - file: wireguard_interface_{{interface_name}}_config
     - require:


### PR DESCRIPTION
Avoid bringing down the tunnel on configuration changes, wg-quick@ supports reloading:
https://git.zx2c4.com/wireguard-tools/tree/src/systemd/wg-quick@.service#n18